### PR TITLE
Checkout branch button from popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitshout",
   "displayName": "GitShout",
   "description": "Accidentally worked on Main again? Even though you promised yourself you wouldn't? GitShout will help you remember.",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,14 @@ function checkAndWarnBranch(repo: Repository) {
   const isWarningBranch = branchesToCheck.includes(repo.state.HEAD?.name?.toLowerCase() ?? '');
 
   if (isWarningBranch) {
-    vscode.window.showWarningMessage(`You're editing ${repo.state.HEAD?.name} branch!`);
+    vscode.window.showWarningMessage(
+      `You're editing ${repo.state.HEAD?.name} branch!`,
+      "Checkout to another branch"
+    ).then((selection) => {
+      if (selection === "Checkout to another branch") {
+        vscode.commands.executeCommand("git.checkout");
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## 📌 Pull Request Summary

Added a button to create a branch from the warning popup

## 🔍 Changes Proposed

- Add a button to the popup
- Use the existing git command to open up the popup to checkout a branch when this button is clicked

## ✅ Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` to ensure code style
- [x] I have updated **documentation** (if applicable)

## 🏁 Related Issues

Closes #14

## 📸 Screenshots (if applicable)

![gitshout_branch-from-popup](https://github.com/user-attachments/assets/d15d3b37-509d-4704-a996-ca3fc180f849)

## 🔄 Testing Instructions

1. Click 'Create Branch' button on warning popup
2. Dropdown to checkout to branch should appear
